### PR TITLE
bug_305_fix

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -196,16 +196,17 @@ def test_work_delete():
     dic=response.json()
 
     for work in dic:
-        if work['project'] == 'test_api_project_public' or  work['project'] == 'test_api_project':
+        if work['project']['name'] == 'test_api_project_public' or  work['project']['name'] == 'test_api_project':
+            time.sleep(10)
             url = '{}/{}/{}'.format(base_url, 'works', work['id'])
             print(work['id'])
             data = None
             response = requests.delete(url, timeout=tout, headers=headers)
             print(response.text)
             assert response.status_code == 200
-            time.sleep(10)
+            time.sleep(30)
             response = requests.get(url, timeout=tout, headers=headers)
-            assert response.status_code != 200
+            assert response.text == '{}\n'
 
 
 def test_project_delete():


### PR DESCRIPTION
Fix [#305](https://github.com/myelintek/MLSteam/issues/305)

1) Wrong conditions in function test_work_delete.
2) Adjust original issue. Get the right project name for work create. Delete project at last.
```diff 
- pytest -s -v test_api.py -k 'test_project_create_private or test_work_create or test_work_delete'
+ pytest -s -v test_api.py -k 'test_project_create_public or test_work_create or test_work_delete or test_project_delete'
```
3) It can not delete the new born container immediately. Despite shows message, but still not delete.
4) Time sleep wait container born and delete correctly.